### PR TITLE
Update Message.cs

### DIFF
--- a/Jiguang.JMessage/Message/Message.cs
+++ b/Jiguang.JMessage/Message/Message.cs
@@ -42,10 +42,11 @@ namespace Jiguang.JMessage.Message
         public string TargetName { get; set; }
 
         /// <summary>
-        /// 当前只限 admin 用户，必须先注册 admin 用户。
+        /// 发送消息者的身份，可为“admin”，“user” 
+        ///<para>必填</para>
         /// </summary>
         [JsonProperty("from_type", Required = Required.Always)]
-        public string FromType { get; } = "admin";
+        public string FromType { get;set; } = "admin";
 
         /// <summary>
         /// 发送方的 username。


### PR DESCRIPTION
from_type	发送消息者的身份，可为“admin”，“user” （必填）

https://docs.jiguang.cn/jmessage/server/rest_api_im/#_18 5
4月份rest API新支持的“在服务端调 API 发消息” 目前服务端未更新